### PR TITLE
Fix issue #1: Non-version folder name in `.../iOS DeviceSupport` causes crash

### DIFF
--- a/lib/xccleanup.rb
+++ b/lib/xccleanup.rb
@@ -128,7 +128,7 @@ module Xccleanup
 		saved_bytes = 0
 
 		ds_folder = File.expand_path('~/Library/Developer/Xcode/iOS DeviceSupport/')
-		ds_versions = get_folders_in_dir(ds_folder)
+		ds_versions = get_folders_in_dir(ds_folder).select { |folder| Gem::Version.correct?(folder.split('/').last.split(' ').first) }
 
 		if ds_versions.length > 0
 			puts "Found versions:"


### PR DESCRIPTION
Fix for issue #1 : Minimal change to exclude non-version folder names from the set of folders processed when removing device support. To avoid unforeseen consequences, the non-version named folders are kept in place, rather than deleted.